### PR TITLE
updated jenkins gid from 498 to 4949

### DIFF
--- a/base.json
+++ b/base.json
@@ -1,19 +1,15 @@
 {
   "variables":{
+    "hvm_amiid":"",
     "build":"",
     "ami_profile":"",
-    "job_tag":"",
-    "software_version":"",
-    "hvm_amiid":"",
     "date":"",
-    "security_group_id":"",
+    "vpc_id":"",
     "subnet_id":"",
     "region":"",
-    "vpc_id":"",
     "instance_type":""
   },
 "builders":[
-
 {
   "name":"hvm_builder",
   "ami_virtualization_type":"hvm",
@@ -21,12 +17,12 @@
   "source_ami": "{{user `hvm_amiid`}}",
   "ssh_username": "ec2-user",
   "associate_public_ip_address": "true",
+  "vpc_id":"{{user `vpc_id`}}",
   "subnet_id":"{{user `subnet_id`}}",
   "instance_type": "{{user `instance_type`}}",
-  "security_group_id":"{{user `security_group_id`}}",
+  "ssh_pty": "true",
   "ssh_timeout":"5m",
   "ssh_private_ip": "true",
-  "vpc_id":"{{user `vpc_id`}}",
   "ami_name": "{{user `ami_profile`}}_build-{{user `build`}}_Source-{{user `hvm_amiid`}}_Built-{{user `date`}}",
   "region":"{{user `region`}}",
   "tags": {

--- a/bin/provision_base_ami
+++ b/bin/provision_base_ami
@@ -6,12 +6,12 @@
 AMI_PROFILES=($(ls *.yml))
 # Timestamp for image
 DATE=$(date +%Y-%m-%d-%H-%M)
+
 # VPC to launch instance in
-VPC_ID=
-# Security group to launch provisioned instance with
-SECURITY_GROUP_ID=
+VPC_ID=${VPC_ID}
 # Subnet ID to launch instance in (Required in VPC)
-SUBNET_ID=
+SUBNET_ID=${SUBNET_ID}
+
 # Region to launch instance in
 REGION=us-west-2
 # Instance type http://www.ec2instances.info/
@@ -35,6 +35,10 @@ if [[ -z "$AMI_PROFILE" ]]; then
   read AMI_PROFILE
 fi
 
+if [ ! -f ${AMI_PROFILE}.yml ]; then
+  eval "echo \"$(< template_ami_profile.yml)\"" > ${AMI_PROFILE}.yml
+fi
+
 # Log file
 LOG=$BUILD_NUMBER-$AMI_PROFILE.log
 
@@ -52,7 +56,6 @@ fi
 -var ami_profile=$AMI_PROFILE \
 -var date=$DATE \
 -var vpc_id=$VPC_ID \
--var security_group_id=$SECURITY_GROUP_ID \
 -var subnet_id=$SUBNET_ID \
 -var region=$REGION \
 -var instance_type=$INSTANCE_TYPE \

--- a/launch_jenkins.yml
+++ b/launch_jenkins.yml
@@ -10,7 +10,7 @@
 
     keyname: jenkins_access
     instance_type: t2.medium
-    linux_ami: ami-e7527ed7
+    linux_ami: ami-9ff7e8af # Amazon Linux AMI 2015.09 was released on 2015-09-22.
     security_group: jenkins
     ami_profile: jenkins
     iam_role: jenkinsRole

--- a/roles/jenkins-user/tasks/main.yml
+++ b/roles/jenkins-user/tasks/main.yml
@@ -1,14 +1,14 @@
 ---
 
 - name: Add group jenkins
-  group: name=jenkins gid=498 state=present
+  group: name=jenkins gid=4949 state=present
   tags:
   - system
   - jenkins-user
   - build
 
 - name: Add  user jenkins
-  user: name=jenkins comment="Jenkins Continuous Build server" home=/var/lib/jenkins shell=/bin/bash uid=498 group=jenkins groups=jenkins state=present
+  user: name=jenkins comment="Jenkins Continuous Build server" home=/var/lib/jenkins shell=/bin/bash uid=4949 group=jenkins groups=jenkins state=present
   tags:
   - system
   - jenkins-user

--- a/roles/jenkins/defaults/main.yml
+++ b/roles/jenkins/defaults/main.yml
@@ -18,6 +18,7 @@ jenkins_plugins:
   - workflow-step-api
   - ws-cleanup
   - plain-credentials
+  - postbuildscript
 
 j_jobs:
   - dsl-ami-provisioning

--- a/roles/jenkins/templates/usr/bin/provision_base_ami
+++ b/roles/jenkins/templates/usr/bin/provision_base_ami
@@ -10,19 +10,19 @@ cd $WORKSPACE
 AMI_PROFILES=($(ls *.yml))
 # Timestamp for image
 DATE=$(date +%Y-%m-%d-%H-%M)
+
+MAC_ADDR=$(/sbin/ifconfig eth0 | grep HWaddr | sed -e 's/.*HWaddr //' | tr -d '[[:space:]]' )
 # VPC to launch instance in
-VPC_ID={{ vpc_id }}
-# Security group to launch provisioned instance with
-SECURITY_GROUP_ID={{ group_id }}
+VPC_ID=$(curl -s http://169.254.169.254/latest/meta-data/network/interfaces/macs/$MAC_ADDR/vpc-id)
 # Subnet ID to launch instance in (Required in VPC)
-SUBNET_ID={{ subnet_public }}
-# Region to launch instance in
-REGION=us-west-2
+SUBNET_ID=$(curl -s http://169.254.169.254/latest/meta-data/network/interfaces/macs/$MAC_ADDR/subnet-id)
+
+REGION=$(curl -s http://169.254.169.254/latest/dynamic/instance-identity/document|grep region|awk -F\" '{print $4}')
+
 # Instance type http://www.ec2instances.info/
 INSTANCE_TYPE=t2.small
 # Packer file
 PACKER_FILE=base.json
-
 
 # Capture some vars if running outside of Jenkins
 if [[ -z "$AMI_ID" ]]; then
@@ -43,7 +43,6 @@ if [ ! -f ${AMI_PROFILE}.yml ]; then
   eval "echo \"$(< template_ami_profile.yml)\"" > ${AMI_PROFILE}.yml
 fi
 
-
 # Log file
 LOG=$BUILD_NUMBER-$AMI_PROFILE.log
 
@@ -51,7 +50,6 @@ LOG=$BUILD_NUMBER-$AMI_PROFILE.log
 if [ -f AMI-$AMI_PROFILE ]; then
   rm -f AMI-$AMI_PROFILE
 fi
-
 
 # Run packer
 /usr/bin/packer build \
@@ -61,7 +59,6 @@ fi
 -var ami_profile=$AMI_PROFILE \
 -var date=$DATE \
 -var vpc_id=$VPC_ID \
--var security_group_id=$SECURITY_GROUP_ID \
 -var subnet_id=$SUBNET_ID \
 -var region=$REGION \
 -var instance_type=$INSTANCE_TYPE \

--- a/roles/jenkins/templates/usr/bin/provision_base_ami
+++ b/roles/jenkins/templates/usr/bin/provision_base_ami
@@ -11,13 +11,13 @@ AMI_PROFILES=($(ls *.yml))
 # Timestamp for image
 DATE=$(date +%Y-%m-%d-%H-%M)
 
-MAC_ADDR=$(/sbin/ifconfig eth0 | grep HWaddr | sed -e 's/.*HWaddr //' | tr -d '[[:space:]]' )
+MAC_ADDR=$(curl -s http://169.254.169.254/latest/meta-data/mac)
 # VPC to launch instance in
-VPC_ID=$(curl -s http://169.254.169.254/latest/meta-data/network/interfaces/macs/$MAC_ADDR/vpc-id)
+VPC_ID=$(curl -s http://169.254.169.254/latest/meta-data/network/interfaces/macs/${MAC_ADDR}/vpc-id)
 # Subnet ID to launch instance in (Required in VPC)
-SUBNET_ID=$(curl -s http://169.254.169.254/latest/meta-data/network/interfaces/macs/$MAC_ADDR/subnet-id)
+SUBNET_ID=$(curl -s http://169.254.169.254/latest/meta-data/network/interfaces/macs/${MAC_ADDR}/subnet-id)
 
-REGION=$(curl -s http://169.254.169.254/latest/dynamic/instance-identity/document|grep region|awk -F\" '{print $4}')
+REGION=$(curl -s http://169.254.169.254/latest/meta-data/placement/availability-zone/ | sed '$s/.$//')
 
 # Instance type http://www.ec2instances.info/
 INSTANCE_TYPE=t2.small

--- a/roles/packer/vars/main.yml
+++ b/roles/packer/vars/main.yml
@@ -1,5 +1,5 @@
 ---
 
 # https://www.packer.io
-packer_version: 0.7.5
+packer_version: 0.8.6
 packer_url: https://dl.bintray.com/mitchellh/packer/packer_{{ packer_version }}_linux_amd64.zip


### PR DESCRIPTION
on linux_ami: ami-9ff7e8af # Amazon Linux AMI 2015.09 was released on 2015-09-22.
gid = 498 seems to be assigned cgred

cgred:x:498: